### PR TITLE
Escape special characters in PR title

### DIFF
--- a/src/main/java/com/pragbits/bitbucketserver/components/PullRequestActivityListener.java
+++ b/src/main/java/com/pragbits/bitbucketserver/components/PullRequestActivityListener.java
@@ -142,17 +142,22 @@ public class PullRequestActivityListener {
             attachment.setAuthorName(userName);
             attachment.setAuthorIcon(avatar);
 
+            String pullRequestTitle = event.getPullRequest().getTitle()
+                    .replaceAll("&", "&amp;")
+                    .replaceAll("<", "&lt;")
+                    .replaceAll(">", "&gt;");
+
             switch (event.getActivity().getAction()) {
                 case OPENED:
                     attachment.setColor(ColorCode.BLUE.getCode());
                     attachment.setFallback(String.format("%s opened pull request \"%s\". <%s|(open)>",
                                                             userName,
-                                                            event.getPullRequest().getTitle(),
+                                                            pullRequestTitle,
                                                             url));
                     attachment.setText(String.format("opened pull request <%s|#%d: %s>",
                                                             url,
                                                             event.getPullRequest().getId(),
-                                                            event.getPullRequest().getTitle()));
+                                                            pullRequestTitle));
 
 
                     if (resolvedLevel == NotificationLevel.COMPACT) {
@@ -168,12 +173,12 @@ public class PullRequestActivityListener {
                     attachment.setColor(ColorCode.BLUE.getCode());
                     attachment.setFallback(String.format("%s reopened pull request \"%s\". <%s|(open)>",
                                                             userName,
-                                                            event.getPullRequest().getTitle(),
+                                                            pullRequestTitle,
                                                             url));
                     attachment.setText(String.format("reopened pull request <%s|#%d: %s>",
                                                             url,
                                                             event.getPullRequest().getId(),
-                                                            event.getPullRequest().getTitle()));
+                                                            pullRequestTitle));
 
                     if (resolvedLevel == NotificationLevel.COMPACT) {
                         this.addField(attachment, "Description", event.getPullRequest().getDescription());
@@ -187,12 +192,12 @@ public class PullRequestActivityListener {
                     attachment.setColor(ColorCode.PURPLE.getCode());
                     attachment.setFallback(String.format("%s updated pull request \"%s\". <%s|(open)>",
                                                             userName,
-                                                            event.getPullRequest().getTitle(),
+                                                            pullRequestTitle,
                                                             url));
                     attachment.setText(String.format("updated pull request <%s|#%d: %s>",
                                                             url,
                                                             event.getPullRequest().getId(),
-                                                            event.getPullRequest().getTitle()));
+                                                            pullRequestTitle));
 
                     if (resolvedLevel == NotificationLevel.COMPACT) {
                         this.addField(attachment, "Description", event.getPullRequest().getDescription());
@@ -206,60 +211,60 @@ public class PullRequestActivityListener {
                     attachment.setColor(ColorCode.GREEN.getCode());
                     attachment.setFallback(String.format("%s approved pull request \"%s\". <%s|(open)>",
                                                             userName,
-                                                            event.getPullRequest().getTitle(),
+                                                            pullRequestTitle,
                                                             url));
                     attachment.setText(String.format("approved pull request <%s|#%d: %s>",
                                                             url,
                                                             event.getPullRequest().getId(),
-                                                            event.getPullRequest().getTitle()));
+                                                            pullRequestTitle));
                     break;
 
                 case UNAPPROVED:
                     attachment.setColor(ColorCode.RED.getCode());
                     attachment.setFallback(String.format("%s unapproved pull request \"%s\". <%s|(open)>",
                                                             userName,
-                                                            event.getPullRequest().getTitle(),
+                                                            pullRequestTitle,
                                                             url));
                     attachment.setText(String.format("unapproved pull request <%s|#%d: %s>",
                                                             url,
                                                             event.getPullRequest().getId(),
-                                                            event.getPullRequest().getTitle()));
+                                                            pullRequestTitle));
                     break;
 
                 case DECLINED:
                     attachment.setColor(ColorCode.DARK_RED.getCode());
                     attachment.setFallback(String.format("%s declined pull request \"%s\". <%s|(open)>",
                                                             userName,
-                                                            event.getPullRequest().getTitle(),
+                                                            pullRequestTitle,
                                                             url));
                     attachment.setText(String.format("declined pull request <%s|#%d: %s>",
                                                             url,
                                                             event.getPullRequest().getId(),
-                                                            event.getPullRequest().getTitle()));
+                                                            pullRequestTitle));
                     break;
 
                 case MERGED:
                     attachment.setColor(ColorCode.DARK_GREEN.getCode());
                     attachment.setFallback(String.format("%s merged pull request \"%s\". <%s|(open)>",
                                                             userName,
-                                                            event.getPullRequest().getTitle(),
+                                                            pullRequestTitle,
                                                             url));
                     attachment.setText(String.format("merged pull request <%s|#%d: %s>",
                                                             url,
                                                             event.getPullRequest().getId(),
-                                                            event.getPullRequest().getTitle()));
+                                                            pullRequestTitle));
                     break;
 
                 case RESCOPED:
                     attachment.setColor(ColorCode.PURPLE.getCode());
                     attachment.setFallback(String.format("%s rescoped on pull request \"%s\". <%s|(open)>",
                                                             userName,
-                                                            event.getPullRequest().getTitle(),
+                                                            pullRequestTitle,
                                                             url));
                     attachment.setText(String.format("rescoped on pull request <%s|#%d: %s>",
                                                             url,
                                                             event.getPullRequest().getId(),
-                                                            event.getPullRequest().getTitle()));
+                                                            pullRequestTitle));
                     break;
 
                 case COMMENTED:
@@ -271,19 +276,19 @@ public class PullRequestActivityListener {
                     attachment.setColor(ColorCode.PALE_BLUE.getCode());
                     attachment.setFallback(String.format("%s commented on pull request \"%s\". <%s|(open)>",
                                                             userName,
-                                                            event.getPullRequest().getTitle(),
+                                                            pullRequestTitle,
                                                             commentUrl));
                     if (resolvedLevel == NotificationLevel.MINIMAL) {
                         attachment.setText(String.format("commented on pull request <%s|#%d: %s>",
                                 commentUrl,
                                 event.getPullRequest().getId(),
-                                event.getPullRequest().getTitle()));
+                                pullRequestTitle));
                     }
                     if (resolvedLevel == NotificationLevel.COMPACT || resolvedLevel == NotificationLevel.VERBOSE) {
                         attachment.setText(String.format("commented on pull request <%s|#%d: %s>\n%s",
                                 commentUrl,
                                 event.getPullRequest().getId(),
-                                event.getPullRequest().getTitle(),
+                                pullRequestTitle,
                                 ((PullRequestCommentActivityEvent) event).getActivity().getComment().getText()));
                     }
                     break;
@@ -291,12 +296,12 @@ public class PullRequestActivityListener {
                     attachment.setColor(ColorCode.ORANGE.getCode());
                     attachment.setFallback(String.format("%s reviewed pull request \"%s\". <%s|(open)>",
                       userName,
-                      event.getPullRequest().getTitle(),
+                      pullRequestTitle,
                       url));
                     attachment.setText(String.format("reviewed pull request <%s|#%d: %s>",
                       url,
                       event.getPullRequest().getId(),
-                      event.getPullRequest().getTitle()));
+                      pullRequestTitle));
                     break;
             }
 

--- a/src/test/java/ut/com/pragbits/bitbucketserver/components/PullRequestActivityListenerTest.java
+++ b/src/test/java/ut/com/pragbits/bitbucketserver/components/PullRequestActivityListenerTest.java
@@ -189,6 +189,20 @@ public class PullRequestActivityListenerTest {
   }
 
   @Test
+  public void notifySlackChannelEscapeHtmlCharactersInPrTitle() throws Exception {
+    when(slackSettings.isSlackNotificationsEnabled()).thenReturn(true);
+    when(slackSettings.isSlackNotificationsOverrideEnabled()).thenReturn(true);
+    when(slackSettings.isSlackNotificationsOpenedEnabled()).thenReturn(true);
+    when(pullRequestRefTo.getDisplayId()).thenReturn(TestFixtures.BUGFIX_REF_ID);
+    when(pullRequest.getTitle()).thenReturn("Upgrade 1.0.0 > 1.0.1 && check that 1 < 2");
+
+    PullRequestActivityListener listener = new PullRequestActivityListener(slackGlobalSettingsService, slackSettingsService, navBuilder, slackNotifier, avatarService);
+    listener.NotifySlackChannel(event);
+
+    verify(slackNotifier).SendSlackNotification(eq(TestFixtures.SLACK_LOCAL_HOOK_URL), eq(TestFixtures.PR_SPECIAL_CHARACTERS_IN_TITLE));
+  }
+
+  @Test
   public void notifySlackChannelEmptyChannel() throws Exception {
     when(slackSettings.isSlackNotificationsEnabled()).thenReturn(true);
     when(slackSettings.isSlackNotificationsOverrideEnabled()).thenReturn(true);

--- a/src/test/java/ut/com/pragbits/bitbucketserver/components/fixtures/TestFixtures.java
+++ b/src/test/java/ut/com/pragbits/bitbucketserver/components/fixtures/TestFixtures.java
@@ -40,6 +40,21 @@ public class TestFixtures {
                                                         "\"icon_url\":\"Local_Icon_Url\"," +
                                                         "\"icon_emoji\":\":rocket:\"}";
 
+  public static final String PR_SPECIAL_CHARACTERS_IN_TITLE = "{\"channel\":\"#local_channel\"," +
+                                                        "\"mrkdwn\":true," +
+                                                        "\"link_names\":true," +
+                                                        "\"attachments\":" +
+                                                        "[{\"mrkdwn_in\":" +
+                                                        "[\"pretext\",\"text\",\"title\",\"fields\",\"fallback\"]," +
+                                                        "\"fields\":[]," +
+                                                        "\"fallback\":\"unknown user opened pull request \\\"Upgrade 1.0.0 \\u0026gt; 1.0.1 \\u0026amp;\\u0026amp; check that 1 \\u0026lt; 2\\\". \\u003chttps://bitbucket_url/pull_request|(open)\\u003e\"," +
+                                                        "\"color\":\"#2267c4\"," +
+                                                        "\"text\":\"opened pull request \\u003chttps://bitbucket_url/pull_request|#99999999999999: Upgrade 1.0.0 \\u0026gt; 1.0.1 \\u0026amp;\\u0026amp; check that 1 \\u0026lt; 2\\u003e\"," +
+                                                        "\"author_name\":\"unknown user\"," +
+                                                        "\"author_icon\":\"\"}]," +
+                                                        "\"icon_url\":\"Local_Icon_Url\"," +
+                                                        "\"icon_emoji\":\":rocket:\"}";
+
   public static final String PR_OVERRIDE_SETTINGS_PAYLOAD = "{\"channel\":\"#local_channel\"," +
                                                         "\"mrkdwn\":true," +
                                                         "\"link_names\":true," +


### PR DESCRIPTION
Correctly display PR titles that contain [special characters](https://api.slack.com/docs/message-formatting#how_to_escape_characters), e.g.

<img width="419" alt="screen shot 2018-11-29 at 11 45 05" src="https://user-images.githubusercontent.com/23170929/49219829-60571d80-f3cc-11e8-8d9a-d2062039cb93.png">

instead of

<img width="420" alt="screen shot 2018-11-29 at 11 44 58" src="https://user-images.githubusercontent.com/23170929/49219836-64833b00-f3cc-11e8-9687-93f78f8f9429.png">

(pull request title is 'Upgrade 1.0.0 > 1.0.1')

Fixes #72 